### PR TITLE
Add LiveKit telephony demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-README.md 
+# LiveKit Telephony Demo
+
+This repo contains a simple example showing how to bridge Twilio voice calls with LiveKit Cloud.
+The demo uses:
+
+- **Twilio** for inbound/outbound PSTN or VoIP calls.
+- **LiveKit Cloud** to handle real-time audio streaming.
+- **Deepgram** for speech-to-text (STT) and text-to-speech (TTS).
+- **OpenAI GPT-4o Mini** as the language model to generate responses.
+
+## Files
+
+- `twiml_server.py` – Flask server that returns TwiML for Twilio. The TwiML connects the call to a LiveKit SIP domain.
+- `livekit_demo.py` – Asynchronous script that dials a phone number and joins the corresponding LiveKit room. It transcribes speech with Deepgram, sends it to GPT‑4o Mini, converts the reply back to speech, and publishes it into the room.
+
+## Usage
+
+1. Set the required environment variables:
+   ```bash
+   export LIVEKIT_WS_URL=wss://your-livekit-url
+   export LIVEKIT_TOKEN=your_livekit_token
+   export LIVEKIT_SIP_DOMAIN=your-sip.livekit.cloud
+   export TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+   export TWILIO_AUTH_TOKEN=your_auth_token
+   export TWILIO_FROM_NUMBER=+15551234567
+   export TO_NUMBER=+15557654321
+   export DEEPGRAM_API_KEY=dg_secret_key
+   export OPENAI_API_KEY=sk-...
+   ```
+
+2. Start the TwiML server:
+   ```bash
+   python twiml_server.py
+   ```
+
+3. Run the demo script to place an outbound call and join the room:
+   ```bash
+   python livekit_demo.py
+   ```
+
+Twilio should be configured to send inbound calls to the `/twiml` endpoint of the server.

--- a/livekit_demo.py
+++ b/livekit_demo.py
@@ -1,0 +1,73 @@
+import os
+import asyncio
+from typing import Optional
+
+from twilio.rest import Client as TwilioClient
+from deepgram import DeepgramClient, LiveOptions, SpeakOptions
+import openai
+from livekit.rtc import Room, RoomOptions
+
+# Environment variables
+LIVEKIT_WS_URL = os.getenv("LIVEKIT_WS_URL")
+LIVEKIT_TOKEN = os.getenv("LIVEKIT_TOKEN")
+LIVEKIT_SIP_DOMAIN = os.getenv("LIVEKIT_SIP_DOMAIN")  # e.g. 'myproject.telephony.livekit.cloud'
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+TWILIO_FROM_NUMBER = os.getenv("TWILIO_FROM_NUMBER")
+DEEPGRAM_API_KEY = os.getenv("DEEPGRAM_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+openai.api_key = OPENAI_API_KEY
+
+twilio_client = TwilioClient(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
+dg_client = DeepgramClient(api_key=DEEPGRAM_API_KEY)
+
+async def transcribe_and_respond(room: Room):
+    """Subscribe to audio tracks, send to Deepgram STT and reply using TTS."""
+    async def on_track_subscribed(track, publication, participant):
+        # Connect to Deepgram's streaming API
+        options = LiveOptions(language="en-US", smart_format=True)
+        dg_socket = dg_client.listen.v("1").websocket
+        dg_conn = dg_socket.open(options=options)
+        dg_conn.start()
+
+        async def handle_dg_events():
+            async for msg in dg_conn.results():
+                if msg.channel and msg.channel.alternatives:
+                    text = msg.channel.alternatives[0].transcript
+                    if text:
+                        print("User:", text)
+                        resp = openai.chat.completions.create(
+                            model="gpt-4o-mini",
+                            messages=[{"role": "user", "content": text}]
+                        )
+                        reply = resp.choices[0].message.content
+                        print("Assistant:", reply)
+                        audio = dg_client.speak.v("1").rest.speak(
+                            SpeakOptions(text=reply, model="aura-asteria")
+                        )
+                        room.local_participant.publish_audio_frame(audio.audio)
+        asyncio.create_task(handle_dg_events())
+
+        async for frame in track.frames():
+            dg_conn.send(frame.data)
+
+    room.on("track_subscribed", on_track_subscribed)
+
+async def start_room() -> Room:
+    room = Room()
+    await room.connect(LIVEKIT_WS_URL, LIVEKIT_TOKEN, RoomOptions())
+    await transcribe_and_respond(room)
+    return room
+
+def dial_twilio(room_name: str, token: str, to_number: str):
+    url = f"https://YOUR_HOST/twiml?room={room_name}&token={token}"
+    call = twilio_client.calls.create(to=to_number, from_=TWILIO_FROM_NUMBER, url=url)
+    print("Started call:", call.sid)
+
+if __name__ == "__main__":
+    to = os.getenv("TO_NUMBER")
+    room_name = os.getenv("LIVEKIT_ROOM", "demo-room")
+    token = LIVEKIT_TOKEN
+    dial_twilio(room_name, token, to)
+    asyncio.run(start_room())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+twilio
+deepgram-sdk
+openai
+livekit
+flask

--- a/twiml_server.py
+++ b/twiml_server.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, Response
+import os
+
+LIVEKIT_SIP_DOMAIN = os.getenv("LIVEKIT_SIP_DOMAIN")
+
+a = Flask(__name__)
+
+@a.route('/twiml', methods=['GET', 'POST'])
+def twiml():
+    room = request.args.get('room')
+    token = request.args.get('token')
+    response = f"""<?xml version='1.0' encoding='UTF-8'?>
+<Response>
+  <Dial>
+    <Sip>sip:{room}@{LIVEKIT_SIP_DOMAIN}?X-LK-TOKEN={token}</Sip>
+  </Dial>
+</Response>"""
+    return Response(response, mimetype='text/xml')
+
+if __name__ == '__main__':
+    a.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))


### PR DESCRIPTION
## Summary
- add LiveKit + Twilio telephony demo using Deepgram and GPT-4o mini
- provide Flask TwiML server for Twilio
- document usage in README

## Testing
- `python -m py_compile livekit_demo.py twiml_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a2d02cf08321a8f3fff88dfe8046